### PR TITLE
fix publishable API Key issue and add migrations directory

### DIFF
--- a/payments/settings.py
+++ b/payments/settings.py
@@ -5,6 +5,7 @@ from .utils import load_path_attr
 
 
 STRIPE_PUBLIC_KEY = settings.STRIPE_PUBLIC_KEY
+STRIPE_SECRET_KEY = settings.STRIPE_SECRET_KEY
 INVOICE_FROM_EMAIL = getattr(
     settings,
     "PAYMENTS_INVOICE_FROM_EMAIL",
@@ -55,3 +56,4 @@ def get_api_key():
         api_key = settings.STRIPE_SECRET_KEY
 
     return api_key
+


### PR DESCRIPTION
Transactions on the frontend, through Stripe.js or checkout.js should be happening with the publishable key (pk_). Whereas, anything happening in the backend (basically the code that only owner can access), would be using the private/secret key (sk_).

Your secret key is the one that has the ability to charge cards, create customers, plans, subscriptions, etc. Your publishable key can only create tokens.
